### PR TITLE
Use ActiveModel::Errors built-in I18n support for error message generation

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -39,8 +39,17 @@ The gem only supports Rails 3 (has dependencies in ActiveModel and ActiveSupport
 
 #### I18n
 
-The default error message `is not a valid email address`.  
-You can pass the `:message => "my custom error"` option to your validation to define your own, custom message.
+The error message will be looked up according to the standard ActiveModel::Errors scheme.
+For the above Unicorn class this would be:
+
+ * activemodel.errors.models.unicorn.attributes.email_address.email
+ * activemodel.errors.models.unicorn.email
+ * activemodel.errors.messages.email
+ * errors.attributes.email_address.email
+ * errors.messages.email
+
+A default errors.messages.email of `is not a valid email address` is provided.
+You can also pass the `:message => "my custom error"` option to your validation to define your own custom message.
 
 ## Authors
 

--- a/Rakefile
+++ b/Rakefile
@@ -4,8 +4,8 @@ require 'rake/clean'
 require 'rspec/core/rake_task'
 require 'jeweler'
 
-desc 'Default: run unit tests.'
-task :default => :test
+desc 'Default: run specs.'
+task :default => :spec
 
 Jeweler::Tasks.new do |jewel|
   jewel.name            = 'validate_email'
@@ -14,7 +14,7 @@ Jeweler::Tasks.new do |jewel|
   jewel.homepage        = 'http://github.com/perfectline/validates_email/tree/master'
   jewel.description     = 'Library for validating email addresses in Rails 3 models.'
   jewel.authors         = ["Tanel Suurhans", "Tarmo Lehtpuu"]
-  jewel.files           = FileList["lib/**/*.rb", "*.rb", "MIT-LICENCE", "README.markdown"]
+  jewel.files           = FileList["lib/**/*.rb", "lib/locale/*.yml", "*.rb", "MIT-LICENCE", "README.markdown"]
 
   jewel.add_development_dependency 'rspec'
   jewel.add_development_dependency 'diff-lcs', '>= 1.1.2'

--- a/lib/locale/en.yml
+++ b/lib/locale/en.yml
@@ -1,0 +1,4 @@
+en:
+  errors:
+    messages:
+      email: is not a valid email address

--- a/lib/validate_email.rb
+++ b/lib/validate_email.rb
@@ -1,3 +1,5 @@
+require 'active_support/i18n'
+I18n.load_path << File.dirname(__FILE__) + '/locale/en.yml'
 require 'active_model'
 require 'mail'
 
@@ -6,12 +8,11 @@ module ActiveModel
     class EmailValidator < ActiveModel::EachValidator
       
       def initialize(options)
-        options.reverse_merge!(:message => "is not a valid email address")
+        options.reverse_merge!(:message => :email)
         super(options)
       end
 
       def validate_each(record, attribute, value)
-        return if options[:allow_nil] && value.nil?
 
         begin
           mail = Mail::Address.new(value)

--- a/spec/resources/user_with_ar.rb
+++ b/spec/resources/user_with_ar.rb
@@ -1,5 +1,5 @@
 class UserWithAr < ActiveRecord::Base
   self.table_name = "users"
 
-  validates :email_address, :email => true
+  validates :email_address, :email => { :message => "is not right" }
 end

--- a/spec/resources/user_with_legacy.rb
+++ b/spec/resources/user_with_legacy.rb
@@ -3,5 +3,5 @@ class UserWithLegacy
 
   attr_accessor :email_address
 
-  validates_email :email_address, :allow_blank => true
+  validates_email :email_address, :allow_blank => true, :message => "is just wrong!"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ $LOAD_PATH.unshift(File.dirname(__FILE__) + '/../lib')
 $LOAD_PATH.unshift(File.dirname(__FILE__) + '/resources')
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 
+require 'validate_email'
 require 'rspec'
 require 'sqlite3'
 require 'active_record'

--- a/spec/validate_email_spec.rb
+++ b/spec/validate_email_spec.rb
@@ -55,6 +55,12 @@ describe "Email validation" do
       @user.email_address = "user@example.com"
       @user.should be_valid
     end
+    
+    it "should return an error message" do
+      @user.email_address = "bad"
+      @user.valid?
+      @user.errors[:email_address].should == ["is not a valid email address"]
+    end
   end
 
   context "with allow nil" do
@@ -72,9 +78,15 @@ describe "Email validation" do
       @user.should_not be_valid
     end
 
-    it "shoild allow a valid email address" do
+    it "should allow a valid email address" do
       @user.email_address = "user@example.com"
       @user.should be_valid
+    end
+    
+    it "should return an error message" do
+      @user.email_address = "bad"
+      @user.valid?
+      @user.errors[:email_address].should == ["is not a valid email address"]
     end
   end
 
@@ -96,6 +108,12 @@ describe "Email validation" do
     it "should allow a valid email address" do
       @user.email_address = "user@example.com"
       @user.should be_valid
+    end
+    
+    it "should return an error message" do
+      @user.email_address = "bad"
+      @user.valid?
+      @user.errors[:email_address].should == ["is not a valid email address"]
     end
   end
 
@@ -123,6 +141,12 @@ describe "Email validation" do
       @user.email_address = "random"
       @user.should_not be_valid
     end
+    
+    it "should return an error message" do
+      @user.email_address = "bad"
+      @user.valid?
+      @user.errors[:email_address].should == ["is just wrong!"]
+    end
   end
 
   context "with ActiveRecord" do
@@ -134,6 +158,12 @@ describe "Email validation" do
       @user.email_address = ""
       @user.should_not be_valid
     end
+    
+    it "should return an error message" do
+      @user.email_address = "bad"
+      @user.valid?
+      @user.errors[:email_address].should == ["is not right"]
+    end
   end
 
   context "with ActiveRecord and legacy syntax" do
@@ -144,6 +174,12 @@ describe "Email validation" do
     it "should not allow invalid email" do
       @user.email_address = ""
       @user.should_not be_valid
+    end
+    
+    it "should return an error message" do
+      @user.email_address = "bad"
+      @user.valid?
+      @user.errors[:email_address].should == ["is not a valid email address"]
     end
   end
 

--- a/validate_email.gemspec
+++ b/validate_email.gemspec
@@ -19,7 +19,8 @@ Gem::Specification.new do |s|
     "README.markdown",
      "init.rb",
      "install.rb",
-     "lib/validate_email.rb"
+     "lib/validate_email.rb",
+     "lib/locale/en.yml"
   ]
   s.homepage = %q{http://github.com/perfectline/validates_email/tree/master}
   s.rdoc_options = ["--charset=UTF-8"]


### PR DESCRIPTION
Use ActiveModel::Errors built-in I18n support for error message generation.
Updated tests and docs.
